### PR TITLE
fix namespace problems & inline normal functions in the header files

### DIFF
--- a/include/boost/text/algorithm.hpp
+++ b/include/boost/text/algorithm.hpp
@@ -235,8 +235,8 @@ namespace boost { namespace text {
     Func foreach_subrange_if(FwdIter first, Sentinel last, Pred p, Func f)
     {
         while (first != last) {
-            first = find_if(first, last, p);
-            auto const next = find_if_not(first, last, p);
+            first = boost::text::find_if(first, last, p);
+            auto const next = boost::text::find_if_not(first, last, p);
             if (first != next)
                 f(foreach_subrange_range<FwdIter, Sentinel>(first, next));
             first = next;

--- a/include/boost/text/bidirectional.hpp
+++ b/include/boost/text/bidirectional.hpp
@@ -576,10 +576,10 @@ namespace boost { namespace text {
             auto it = seq.end();
             auto const first = seq.begin();
             while (it != first) {
-                auto const from_it = find_if_backward(first, it, en);
+                auto const from_it = boost::text::find_if_backward(first, it, en);
                 if (from_it == it)
                     break;
-                auto const pred_it = find_if_backward(first, from_it, strong);
+                auto const pred_it = boost::text::find_if_backward(first, from_it, strong);
                 if ((pred_it == from_it && seq.sos() == trigger) ||
                     pred_it->prop() == trigger) {
                     from_it->prop_ = (uint8_t)replacement;

--- a/include/boost/text/collation_search.hpp
+++ b/include/boost/text/collation_search.hpp
@@ -125,7 +125,7 @@ namespace boost { namespace text {
             }
         };
 
-        collation_element adjust_ce_for_search(
+        collation_element inline adjust_ce_for_search(
             collation_element ce,
             collation_strength strength,
             case_level case_lvl) noexcept


### PR DESCRIPTION
1. Force to use boost::text:: namespace prefix in case of conflicting with STL functions;
2. Functions other than using template or inline should not be defined in the header files. Since only one normal function has been found in the header file, I choose to set it as an inline function to make it compile. #110

These problems can be reproduced on Clang 10.0 on OS X 10.14, Visual C++ 2019 v141_xp toolset on Windows 10.