### PR TITLE
Fixes for gcc 10.1

### DIFF
--- a/include/boost/stl_interfaces/container_interface.hpp
+++ b/include/boost/stl_interfaces/container_interface.hpp
@@ -97,7 +97,7 @@ namespace boost { namespace stl_interfaces { inline namespace v1 {
         std::ranges::end(d))`. */
     template<
         typename Derived,
-        bool Contiguous = discontiguous
+        bool Contiguous = element_layout::discontiguous
 #ifndef BOOST_STL_INTERFACES_DOXYGEN
         ,
         typename E = std::enable_if_t<

--- a/include/boost/stl_interfaces/reverse_iterator.hpp
+++ b/include/boost/stl_interfaces/reverse_iterator.hpp
@@ -63,11 +63,7 @@ namespace boost { namespace stl_interfaces { inline namespace v1 {
     struct reverse_iterator
         : iterator_interface<
               reverse_iterator<BidiIter>,
-#if 201703L < __cplusplus && defined(__cpp_lib_ranges)
-              typename std::iterator_traits<BidiIter>::iterator_concept,
-#else
               typename std::iterator_traits<BidiIter>::iterator_category,
-#endif
               typename std::iterator_traits<BidiIter>::value_type,
               typename std::iterator_traits<BidiIter>::reference,
               typename std::iterator_traits<BidiIter>::pointer,

--- a/include/boost/stl_interfaces/view_interface.hpp
+++ b/include/boost/stl_interfaces/view_interface.hpp
@@ -209,7 +209,7 @@ namespace boost { namespace stl_interfaces { namespace v2 {
     /** A template alias for `std::view_interface`.  This only exists to make
         migration from Boost.STLInterfaces to C++20 easier; switch to the one
         in `std` as soon as you can. */
-    template<typename D, bool = v1::discontiguous>
+    template<typename D, bool = v1::element_layout::discontiguous>
     using view_interface = std::ranges::view_interface<D>;
 
 }}}

--- a/include/boost/stl_interfaces/view_interface.hpp
+++ b/include/boost/stl_interfaces/view_interface.hpp
@@ -8,6 +8,9 @@
 
 #include <boost/stl_interfaces/fwd.hpp>
 
+#if 201703L < __cplusplus && defined(__cpp_lib_concepts)
+#include <ranges>
+#endif
 
 namespace boost { namespace stl_interfaces { inline namespace v1 {
 

--- a/include/boost/stl_interfaces/view_interface.hpp
+++ b/include/boost/stl_interfaces/view_interface.hpp
@@ -8,7 +8,7 @@
 
 #include <boost/stl_interfaces/fwd.hpp>
 
-#if 201703L < __cplusplus && defined(__cpp_lib_concepts)
+#if 201703L < __cplusplus && defined(__cpp_lib_ranges)
 #include <ranges>
 #endif
 
@@ -204,7 +204,7 @@ namespace boost { namespace stl_interfaces { inline namespace v1 {
 }}}
 
 
-#if 201703L < __cplusplus && defined(__cpp_lib_concepts) ||                    \
+#if 201703L < __cplusplus && defined(__cpp_lib_ranges) ||                      \
     defined(BOOST_STL_INTERFACES_DOXYGEN)
 
 namespace boost { namespace stl_interfaces { namespace v2 {


### PR DESCRIPTION
I ran into a handful of issues after upgrading to gcc 10.1 (see below). I'm guessing some of this is because it looks like 10.1 added ranges support? I didn't think about this in depth -- please feel free to rework this stuff or use it as is.

Sorry, I know there is overlap with the stl_interfaces repo. Thanks!