### PR TITLE
Fix utf_16_to_32_iterator not advancing on invalid surrogate pairs.

### DIFF
--- a/include/boost/text/transcode_iterator.hpp
+++ b/include/boost/text/transcode_iterator.hpp
@@ -2363,26 +2363,23 @@ namespace boost { namespace text {
         get_value(uint16_t curr) const noexcept(!throw_on_error)
         {
             uint32_t value = 0;
-            I next = it_;
+            I next = std::next(it_);
 
             if (high_surrogate(curr)) {
                 value = (curr - high_surrogate_base) << 10;
-                ++next;
                 if (at_end(next)) {
                     return get_value_result{replacement_character(), next};
                 }
-                curr = *next;
+                curr = *next++;
                 if (!low_surrogate(curr)) {
                     return get_value_result{replacement_character(), next};
                 }
                 value += curr - low_surrogate_base;
-                ++next;
             } else if (low_surrogate(curr)) {
                 value = ErrorHandler{}("Invalid initial UTF-16 code unit.");
                 return get_value_result{replacement_character(), next};
             } else {
                 value = curr;
-                ++next;
             }
 
             if (!valid_code_point(value)) {

--- a/test/utf16.cpp
+++ b/test/utf16.cpp
@@ -227,3 +227,38 @@ TEST(utf_16, test_back_and_forth)
         }
     }
 }
+
+TEST(utf_16, invalid_surrogate_pairs)
+{
+    // UTF-16 -> UTF-32 low surrogate without high surrogate
+    {
+        uint32_t const utf32[] = {0xfffd};
+        uint16_t const utf16[] = {0xdc00};
+
+        auto it = text::utf_16_to_32_iterator<uint16_t const *>(
+            std::begin(utf16), std::begin(utf16), std::end(utf16));
+
+        auto end = text::utf_16_to_32_iterator<uint16_t const *>(
+            std::begin(utf16), std::end(utf16), std::end(utf16));
+
+        EXPECT_EQ(*it, utf32[0]);
+        ++it;
+        EXPECT_EQ(it, end);
+    }
+
+    // UTF-16 -> UTF-32 valid high surrogate, invalid low surrogate
+    {
+        uint32_t const utf32[] = {0xfffd};
+        uint16_t const utf16[] = {0xd800, 0xdb00};
+
+        auto it = text::utf_16_to_32_iterator<uint16_t const *>(
+            std::begin(utf16), std::begin(utf16), std::end(utf16));
+
+        auto end = text::utf_16_to_32_iterator<uint16_t const *>(
+            std::begin(utf16), std::end(utf16), std::end(utf16));
+
+        EXPECT_EQ(*it, utf32[0]);
+        ++it;
+        EXPECT_EQ(it, end);
+    }
+}


### PR DESCRIPTION
When encountering invalid surrogate pair `utf_16_to_32_iterator` never advances past that point leading to an infinite loop.