### PR TITLE
Fix utf_16_to_8_iterator stack overflow on partial surrogate pair.

### DIFF
--- a/include/boost/text/transcode_iterator.hpp
+++ b/include/boost/text/transcode_iterator.hpp
@@ -2768,9 +2768,10 @@ namespace boost { namespace text {
 
 #ifndef BOOST_TEXT_DOXYGEN
     private:
-        BOOST_TEXT_CXX14_CONSTEXPR bool at_end() const noexcept(!throw_on_error)
+        BOOST_TEXT_CXX14_CONSTEXPR bool at_end(I it) const
+            noexcept(!throw_on_error)
         {
-            if (it_ == last_) {
+            if (it == last_) {
                 ErrorHandler{}(
                     "Invalid UTF-16 sequence; expected another code unit "
                     "before the end of string.");
@@ -2794,10 +2795,10 @@ namespace boost { namespace text {
             uint32_t second = 0;
             uint32_t cp = first;
             if (boost::text::high_surrogate(first)) {
-                if (at_end())
+                if (at_end(++next))
                     cp = replacement_character();
                 else {
-                    second = static_cast<uint32_t>(*++next);
+                    second = static_cast<uint32_t>(*next);
                     if (!boost::text::low_surrogate(second)) {
                         ErrorHandler{}(
                             "Invalid UTF-16 sequence; expected low surrogate "

--- a/test/utf8.cpp
+++ b/test/utf8.cpp
@@ -1040,3 +1040,23 @@ TEST(utf_8, make_utfN_iterator)
         EXPECT_EQ(result, expected);
     }
 }
+
+TEST(utf8, utf_16_to_8_incomplete_surrogate_pair)
+{
+    uint16_t const utf16[] = {0xd800};
+    char const utf8[] = {char(0xef),
+                         char(0xbf),
+                         char(0xbd),
+                         0};
+
+    auto it = text::utf_16_to_8_iterator<uint16_t const *>(
+        std::begin(utf16), std::begin(utf16), std::end(utf16));
+
+    auto const end = text::utf_16_to_8_iterator<uint16_t const *>(
+        std::begin(utf16), std::end(utf16), std::end(utf16));
+
+    EXPECT_EQ(*it++, utf8[0]);
+    EXPECT_EQ(*it++, utf8[1]);
+    EXPECT_EQ(*it++, utf8[2]);
+    EXPECT_EQ(it, end);
+}


### PR DESCRIPTION
`at_end()` was checking iterator before it was incremented, then the increment happens, then dereference of unchecked iterator. Compile with USE_ASAN.